### PR TITLE
chore: statistics from stdin and file, making use of the new API [sc-642]

### DIFF
--- a/Sources/LatencyStatisticsCLI/main.swift
+++ b/Sources/LatencyStatisticsCLI/main.swift
@@ -1,17 +1,50 @@
 import LatencyStatistics
 
+func parseNumbersFromString(_ content: String) -> [Int] {
+    let stringNumbers = content.split { char in
+        if char.isNumber {
+            return false
+        } else {
+            return true
+        }
+    }
+    return stringNumbers.map { Int($0)! }
+}
+
 func main() {
     let argc = CommandLine.argc
     guard argc == 2 else {
-        print("There should be one argument - file name")
+        print("There should be one argument - file name or '-' for reading from stdin")
         return
     }
 
-//    let fileName = CommandLine.arguments[1]
+    do {
+        var statistics = LatencyStatistics()
+        let fileName = CommandLine.arguments[1]
 
-//    var statistics = LatencyStatistics()
-//    statistics.process(fileName: fileName)
-//    statistics.printStatistics();
+        if fileName == "-" {
+            while let content = readLine(strippingNewline: true) {
+                let measurements = parseNumbersFromString(content)
+
+                for input in measurements {
+                    statistics.add(input)
+                }
+            }
+        } else {
+            let content = try String(contentsOfFile: fileName)
+
+            let measurements = parseNumbersFromString(content)
+
+            for input in measurements {
+                statistics.add(input)
+            }
+        }
+
+        print(statistics.output())
+    } catch {
+        print(error)
+        return
+    }
 }
 
 main()


### PR DESCRIPTION
## Description

Read from stdin or a file and generate stats.

Fixes Shortcut story [sc-642]




```
cat out_raw | swift run LatencyStatisticsCLI -
Building for debugging...
Build complete! (0.08s)
Percentile measurements (999 samples, average 24.44):
      50.0 <= 16μs 
      80.0 <= 32μs 
      99.0 <= 67μs 
      99.9 <= 256μs 
     100.0 <= 256μs 

Linear histogram (999 samples): 
         9 = *
        10 = *
        11 = **
        12 = ********
        13 = ***************
        14 = ***********
[...]
```